### PR TITLE
migration default values

### DIFF
--- a/db/migrate/20220817155824_add_default_to_is_active_in_ghost.rb
+++ b/db/migrate/20220817155824_add_default_to_is_active_in_ghost.rb
@@ -1,0 +1,5 @@
+class AddDefaultToIsActiveInGhost < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :ghosts, :is_active, true
+  end
+end

--- a/db/migrate/20220817160716_add_default_to_status_in_spooks.rb
+++ b/db/migrate/20220817160716_add_default_to_status_in_spooks.rb
@@ -1,0 +1,5 @@
+class AddDefaultToStatusInSpooks < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :spooks, :status, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_16_181040) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_17_160716) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,7 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_181040) do
   create_table "ghosts", force: :cascade do |t|
     t.string "name"
     t.string "spook_action"
-    t.boolean "is_active"
+    t.boolean "is_active", default: true
     t.string "location"
     t.text "description"
     t.float "daily_rate"
@@ -68,7 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_181040) do
     t.date "start_date"
     t.date "end_date"
     t.float "total_price"
-    t.integer "status"
+    t.integer "status", default: 0
     t.bigint "ghost_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
In this PR we have two migrations
1. adds the default value of 0 to status for spooks. (pending)
2. Adds the default value of true to is_active for ghosts.